### PR TITLE
double quotes, warn on no-shadow

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,7 +25,7 @@
       }
     ],
     "no-console": 1,
-    "quotes": ["error", "single", { "allowTemplateLiterals": true }],
+    "quotes": ["warn", "double", { "allowTemplateLiterals": true }],
     "func-names": 0,
     "space-unary-ops": 2,
     "space-in-parens": "error",
@@ -37,7 +37,7 @@
     "consistent-return": 0,
     "radix": 0,
     "no-shadow": [
-      2,
+      "warn",
       {
         "hoist": "all",
         "allow": ["resolve", "reject", "done", "next", "err", "error"]


### PR DESCRIPTION
the no-shadow was too hasty to throw an error, now set to warn only.